### PR TITLE
Add GH Action to publish to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+# This workflow is triggered two ways:
+#
+# 1. When a tag is created, the workflow will upload the package to
+#    test.pypi.org.
+# 2. When a release is made, the workflow will upload the package to pypi.org.
+#
+# It is done this way until PyPI has draft reviews, to allow for a two-stage
+# upload with a chance for manual intervention before the final publication.
+name: Upload package
+
+on:
+  release:
+    types: [created]
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U tox
+    - name: Create tox environments
+      run: |
+        tox -p -e py,build,release --notest
+    - name: Run tests
+      run: |
+        tox -e py
+    - name: Build package
+      run: |
+        tox -e build
+    - name: Publish package
+      env:
+        TWINE_USERNAME: "__token__"
+      run: |
+        if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+          export TWINE_REPOSITORY_URL="https://test.pypi.org/legacy/"
+          export TWINE_PASSWORD="${{ secrets.TEST_PYPI_UPLOAD_TOKEN }}"
+        elif [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+          export TWINE_REPOSITORY="pypi"
+          export TWINE_PASSWORD="${{ secrets.PYPI_UPLOAD_TOKEN }}"
+        else
+          echo "Unknown event name: ${GITHUB_EVENT_NAME}"
+          exit 1
+        fi
+
+        tox -e release

--- a/tox.ini
+++ b/tox.ini
@@ -48,5 +48,21 @@ deps =
     pep517
     twine
 commands =
+    python -c "from pathlib import Path; \
+               [x.unlink(missing_ok=True) for x in Path('{toxinidir}/dist').glob('*')]"
     python -m pep517.build -s -b {toxinidir} -o {toxinidir}/dist
     twine check {toxinidir}/dist/*
+
+[testenv:release]
+description = Make a release; must be called after "build"
+skip_install = True
+deps =
+    twine
+depends =
+    build
+passenv =
+    TWINE_*
+commands =
+    twine check {toxinidir}/dist/*
+    twine upload {toxinidir}/dist/* \
+                 {posargs:-r testpypi --non-interactive}


### PR DESCRIPTION
Closes #4.

The release procedure also needs to be documented in the user-facing documentation, but I'd like to get this done sooner rather than later because `zoneinfo` has a dependency on this, and I'd rather point it at PyPI than at github.

@webknjaz Do you mind taking a look at this?