### PR TITLE
Override -r from TWINE_REPOSITORY

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,4 +92,4 @@ passenv =
 commands =
     twine check {toxinidir}/dist/*
     twine upload {toxinidir}/dist/* \
-                 {posargs:-r testpypi --non-interactive}
+                 {posargs:-r {env:TWINE_REPOSITORY:testpypi} --non-interactive}


### PR DESCRIPTION
Apparently the precedence for twine goes like this:

1. --repository-url
2. TWINE_REPOSITORY_URL
3. -r
4 TWINE_REPOSITORY

But I was counting on TWINE_REPOSITORY to override the -r flag. This
wasn't an issue for the Test PyPI job because that uses
TWINE_REPOSITORY_URL rather than TWINE_REPOSITORY.