### PR TITLE
Pin pep517 to 0.8.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
 description = Build a wheel and source distribution
 skip_install = True
 deps =
-    pep517
+    pep517==0.8.2
     twine
 commands =
     python -c "from pathlib import Path; \


### PR DESCRIPTION
pep517 will apparently soon drop the pep517.build CLI, suddenly. No replacement is available, so we will pin to the latest version that supports it.

https://github.com/pypa/pep517/pull/83