### PR TITLE
Include NEWS.md in source dists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 # All the stuff to include
 include VERSION
 include tox.ini
-include LICENSE *.rst *.toml *.yml *.yaml *.ini *.sh *.cfg
+include LICENSE *.md *.rst *.toml *.yml *.yaml *.ini *.sh *.cfg
 recursive-include licenses *
 recursive-include src/tzdata *
 recursive-include templates *

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # Version 2020.3
-Upstream version 2020c release 2020-10-16T18:15:53+00:00
+Upstream version 2020c released 2020-10-16T18:15:53+00:00
 
 ## Briefly:
 
@@ -15,7 +15,7 @@ departure from the recent pattern.
 ---
 
 # Version 2020.2
-Upstream version 2020b release 2020-10-07T01:35:04+00:00
+Upstream version 2020b released 2020-10-07T01:35:04+00:00
 
 ## Briefly:
 
@@ -66,7 +66,7 @@ from the distribution.  (Thanks to Tim Parenti.)
 ---
 
 # Version 2020.1
-Upstream version 2020a release 2020-04-23T23:03:47+00:00
+Upstream version 2020a released 2020-04-23T23:03:47+00:00
 
 ## Briefly:
 

--- a/news.d/2020a.md
+++ b/news.d/2020a.md
@@ -1,5 +1,5 @@
 # Version 2020.1
-Upstream version 2020a release 2020-04-23T23:03:47+00:00
+Upstream version 2020a released 2020-04-23T23:03:47+00:00
 
 ## Briefly:
 

--- a/news.d/2020b.md
+++ b/news.d/2020b.md
@@ -1,5 +1,5 @@
 # Version 2020.2
-Upstream version 2020b release 2020-10-07T01:35:04+00:00
+Upstream version 2020b released 2020-10-07T01:35:04+00:00
 
 ## Briefly:
 

--- a/news.d/2020c.md
+++ b/news.d/2020c.md
@@ -1,5 +1,5 @@
 # Version 2020.3
-Upstream version 2020c release 2020-10-16T18:15:53+00:00
+Upstream version 2020c released 2020-10-16T18:15:53+00:00
 
 ## Briefly:
 

--- a/update.py
+++ b/update.py
@@ -226,7 +226,7 @@ class NewsEntry:
 
         contents = [f"# Version {translated_version}"]
         contents.append(
-            f"Upstream version {self.version} release {release_date.isoformat()}"
+            f"Upstream version {self.version} released {release_date.isoformat()}"
         )
         contents.append("")
 


### PR DESCRIPTION
I didn't check that `MANFEST.in` would include this file.

We still don't include the `news.d` directory. I am not sure if we should, but I don't think it's necessary, since `news.d` is really more of a convenience for easily re-generating `NEWS.md` in an idempotent manner.