### PR TITLE
Add type stubs for requests and click

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,8 @@ skip_install = True
 deps =
     mypy
     parver
+    types-requests
+    types-click
 commands =
     mypy {posargs} update.py
     mypy {posargs} bump_version.py


### PR DESCRIPTION
This fixes some bitrot in the CI system — apparently the type stubs for these libraries are now distributed separately.