### PR TITLE
Use `pypa/build` in favor of `pep517.build`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -73,12 +73,12 @@ commands =
 description = Build a wheel and source distribution
 skip_install = True
 deps =
-    pep517
+    build
     twine
 commands =
     python -c "from pathlib import Path; \
                [x.unlink(missing_ok=True) for x in Path('{toxinidir}/dist').glob('*')]"
-    python -m pep517.build -s -b {toxinidir} -o {toxinidir}/dist
+    python -m build -s -w -o {toxinidir}/dist {toxinidir}
     twine check {toxinidir}/dist/*
 
 [testenv:release]

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ deps =
 commands =
     python -c "from pathlib import Path; \
                [x.unlink(missing_ok=True) for x in Path('{toxinidir}/dist').glob('*')]"
-    python -m build -s -w -o {toxinidir}/dist {toxinidir}
+    python -m build -o {toxinidir}/dist {toxinidir}
     twine check {toxinidir}/dist/*
 
 [testenv:release]


### PR DESCRIPTION
`pep517.build` is deprecated and has various bugs related to isolation, and `pypa/build` has matured quite a bit.

Supercedes #27.