### PR TITLE
Add Python 3.10 to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     env:
       TOXENV: py


### PR DESCRIPTION
At some point we should probably also start testing against upstream dev branches as well, though honestly that'll be more likely to cause breakages due to random bitrot in the testing stack than anything wrong with this library.