### PR TITLE
Remove tag signing

### DIFF
--- a/tag_release.sh
+++ b/tag_release.sh
@@ -3,5 +3,5 @@ set -e
 VERSION=$(<VERSION)
 
 echo "Tagging version $VERSION"
-git tag -s -m "Version $VERSION" $VERSION || exit "Failed to tag!"
+git tag -m "Version $VERSION" $VERSION || exit "Failed to tag!"
 echo "Success"


### PR DESCRIPTION
I no longer really believe GPG signatures are a very useful signal here, and they are a bit of a pain to continue maintaining, so I'm dropping the tag signing.