### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,24 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.6.0
     hooks:
       - id: black
         language_version: python3.8
 
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.5.4
+    rev: v5.10.1
     hooks:
       - id: isort
         additional_dependencies: [toml]
         language_version: python3.8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: debug-statements
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.14.0
+    rev: v2.0.0
     hooks:
     -   id: setup-cfg-fmt


### PR DESCRIPTION
The 2022b update is failing on pre-commit.