### PR TITLE
Upgrade versions in github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: ${{ matrix.toxenv }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: Install tox
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
       TOXENV: py
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: ${{ matrix.python-version }} - ${{ matrix.os }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -36,9 +36,9 @@ jobs:
       TOXENV: ${{ matrix.toxenv }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: ${{ matrix.toxenv }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     env:
       TOXENV: py


### PR DESCRIPTION
Test against 3.11, use latest versions of actions and a newer python version for the "other" tests.