### PR TITLE
Fix broken test configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,16 @@ jobs:
       matrix:
         python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        exclude:
+          - python-version: "2.7"
+            os: "ubuntu-latest"
+          - python-version: "3.6"
+            os: "ubuntu-latest"
+        include:
+          - python-version: "2.7"
+            os: "ubuntu-20.04"
+          - python-version: "3.6"
+            os: "ubuntu-20.04"
     env:
       TOXENV: py
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,24 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: "python3.10"
 
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:
       - id: isort
         additional_dependencies: [toml]
-        language_version: python3.8
+        language_version: "python3.10"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: debug-statements
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.0.0
+    rev: v2.2.0
     hooks:
     -   id: setup-cfg-fmt

--- a/bump_version.py
+++ b/bump_version.py
@@ -65,6 +65,8 @@ def bump_version(version: parver.Version, args) -> parver.Version:
         else:
             return version.bump_pre("rc")
 
+    return version
+
 
 def main(args):
     original_version = get_current_version()


### PR DESCRIPTION
This fixes a few problems:

1. Python 2.7 and 3.6 are no longer supported on `ubuntu-latest`, so we now test those on `ubuntu-20.04`.
2. There were some issues with recent versions of `mypy`, so I've updated some of the typing in the various scripts.
3. The pre-commit configuration was specifying the language version as 3.8, which is getting too old as well. I ran `pre-commit autoupdate` to update to the latest configuration there as well.