### PR TITLE
Deprecate Europe/Kiev in favor of Europe/Kyiv

### DIFF
--- a/src/tzdata/zones
+++ b/src/tzdata/zones
@@ -591,7 +591,6 @@ Asia/Thimbu
 Asia/Ujung_Pandang
 Asia/Ulan_Bator
 Atlantic/Faeroe
-Europe/Kiev
 Europe/Nicosia
 Pacific/Ponape
 Pacific/Truk


### PR DESCRIPTION
The proper spelling of Ukrainian capital is Kyiv, not Kiev - for some reason zones have both values

More information: https://en.wikipedia.org/wiki/KyivNotKiev