### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["2.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         exclude:
           - python-version: "2.7"
@@ -18,12 +18,8 @@ jobs:
             os: "macos-latest"
           - python-version: "2.7"
             os: "ubuntu-latest"
-          - python-version: "3.6"
-            os: "ubuntu-latest"
         include:
           - python-version: "2.7"
-            os: "ubuntu-20.04"
-          - python-version: "3.6"
             os: "ubuntu-20.04"
     env:
       TOXENV: py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         exclude:
           - python-version: "2.7"


### PR DESCRIPTION
The Python 3.13 release candidate is out now! :rocket:

The Release Manager has issued a [call to action](https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703?u=hugovk]):

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc1 **will work** with future versions of Python 3.13. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).