### PR TITLE
Add action to automatically check for updates and create a PR

### DIFF
--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -1,0 +1,111 @@
+name: Check for tzdata updates
+
+on:
+  schedule:
+    - cron: '0 9 * * *'  # Runs daily at 9AM UTC
+  workflow_dispatch:
+
+jobs:
+  check-pr-exists:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_exists: ${{ steps.check_pr_exists.outputs.pr_exists }}
+    steps:
+      - name: Check if PR already exists
+        id: check_pr_exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_EXISTS=$(gh pr --repo $GITHUB_REPOSITORY \
+                      list --search "Update tzdata to version" \
+                      --json number --jq '.[] | .number')
+          if [ -n "$PR_EXISTS" ]; then
+            echo "A PR updating the tzdata version already exists: https://github.com/python/tzdata/pulls/${PR_EXISTS}"
+            echo "pr_exists=true" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "pr_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+  check-for-updates:
+    runs-on: ubuntu-latest
+    needs: check-pr-exists
+    permissions:
+      pull-requests: write
+      contents: write
+    if: needs.check-pr-exists.outputs.pr_exists == 'false'  # Run only if no PR exists
+    steps:
+      - name: Check out repository (shallow)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1  # Shallow clone to save time
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install tox
+          sudo apt-get install gh
+
+      - name: Run tox update
+        run: tox -e update
+
+      - name: Check for repository changes and commit
+        id: check_changes
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
+          # Check for changes
+          if git diff --quiet; then
+            echo "No changes detected."
+            echo "CHANGES_DETECTED=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          # Check for changes in the news.d directory
+          git add -A
+          news_files=$(git diff --cached --name-only --diff-filter=A | grep '^news.d/.*\.md' || true)
+
+          if [ -z "$news_files" ]; then
+            echo "No new file in news.d, failing the job."
+            exit 1
+          fi
+
+          if [ $(echo "$news_files" | wc -l) -ne 1 ]; then
+            echo "More than one new file added in news.d, failing the job."
+            exit 1
+          fi
+          echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+
+          # Extract TZDATA_VERSION from filename
+          TZDATA_VERSION=$(basename "$news_files" .md)
+
+          # Extract TZDATA_NEWS from file content
+          TZDATA_NEWS=$(cat "$news_files")
+
+          echo "TZDATA_VERSION=$TZDATA_VERSION" >> $GITHUB_ENV
+          echo "TZDATA_NEWS=$TZDATA_NEWS" >> $GITHUB_ENV
+
+      - name: Commit changes
+        id: commit_changes
+        if: env.CHANGES_DETECTED == 'true'
+        run: |
+          git checkout -b "updates/update_${TZDATA_VERSION}"
+          git commit -m "Update tzdata to version $TZDATA_VERSION" \
+                     -m "$TZDATA_NEWS"
+          git push --force origin "updates/update_${TZDATA_VERSION}"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: env.CHANGES_DETECTED == 'true'
+        run: |
+          gh pr create --title "Update tzdata to version $TZDATA_VERSION" \
+            --body "$TZDATA_NEWS" \
+            --base master \
+            --head $(git rev-parse --abbrev-ref HEAD) \
+            --label "automatic-updates"


### PR DESCRIPTION
First thing to do is to make sure that the `tox -e update` script doesn't do anything if you are already on the latest version. If it finds anything, we're ready for an update. This will create a release candidate.

Fixes #8 