### PR TITLE
Quote variable contents in update checker

### DIFF
--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -87,8 +87,12 @@ jobs:
           # Extract TZDATA_NEWS from file content
           TZDATA_NEWS=$(cat "$news_files")
 
-          echo "TZDATA_VERSION=$TZDATA_VERSION" >> $GITHUB_ENV
-          echo "TZDATA_NEWS=$TZDATA_NEWS" >> $GITHUB_ENV
+          echo "TZDATA_VERSION='$TZDATA_VERSION'" >> $GITHUB_ENV
+          {
+            echo 'TZDATA_NEWS<<EOF'
+            echo $TZDATA_NEWS
+            echo EOF
+          } >> "$GITHUB_ENV"
 
       - name: Commit changes
         id: commit_changes


### PR DESCRIPTION
Per [the Github documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings), multiline strings must use a delimiter
with the following syntax:

```
{name}<<{delimiter}
{value}
{delimiter}
```

[Testing this with my fork](https://github.com/pganssle/tzdata/actions/runs/12894349602) indicates that it should work.