### PR TITLE
Change Sphinx theme to furo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import sphinx_bootstrap_theme
-
 import tzdata
 
 # -- Project information -----------------------------------------------------
@@ -37,11 +35,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "bootstrap"
-html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
-html_theme_options = {
-    "bootswatch_theme": "cosmo",
-}
+html_theme = "furo"
 
 # For cross-links to other documentation
 intersphinx_mapping = {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 sphinx>=3.0.0
-sphinx_bootstrap_theme
+furo


### PR DESCRIPTION
I propose changing the theme to [Furo](https://github.com/pradyunsg/furo), currently used by the [devguide](devguide.python.org) as I find the docs a tad confusing (navbar has links that do nothing and the sidebar decides to disappear when you scroll down?)