### PR TITLE
Migrate to trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,11 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/tzdata
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -30,26 +35,18 @@ jobs:
         pip install -U tox
     - name: Create tox environments
       run: |
-        tox -p -e py,build,release --notest
+        tox -p -e py,build --notest
     - name: Run tests
       run: |
         tox -e py
     - name: Build package
       run: |
         tox -e build
+    - name: Publish package (TestPyPI)
+      if: github.event_name == 'push'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
     - name: Publish package
-      env:
-        TWINE_USERNAME: "__token__"
-      run: |
-        if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-          export TWINE_REPOSITORY_URL="https://test.pypi.org/legacy/"
-          export TWINE_PASSWORD="${{ secrets.TEST_PYPI_UPLOAD_TOKEN }}"
-        elif [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
-          export TWINE_REPOSITORY="pypi"
-          export TWINE_PASSWORD="${{ secrets.PYPI_UPLOAD_TOKEN }}"
-        else
-          echo "Unknown event name: ${GITHUB_EVENT_NAME}"
-          exit 1
-        fi
-
-        tox -e release
+      if: github.event_name == 'release'
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,9 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        verbose: true
     - name: Publish package
       if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true

--- a/tox.ini
+++ b/tox.ini
@@ -80,17 +80,3 @@ commands =
                [x.unlink(missing_ok=True) for x in Path('{toxinidir}/dist').glob('*')]"
     python -m build -o {toxinidir}/dist {toxinidir}
     twine check {toxinidir}/dist/*
-
-[testenv:release]
-description = Make a release; must be called after "build"
-skip_install = True
-deps =
-    twine
-depends =
-    build
-passenv =
-    TWINE_*
-commands =
-    twine check {toxinidir}/dist/*
-    twine upload {toxinidir}/dist/* \
-                 {posargs:-r {env:TWINE_REPOSITORY:testpypi} --non-interactive}


### PR DESCRIPTION
This enables trusted publishing and migrates to using the pypa release action.