### PR TITLE
Stop trying to test 2.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - if: ${{ matrix.python-version == '2.7' }}
-      run: |
-        sudo apt-get install python-is-python2
-        curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
-        python get-pip.py
-    - if: ${{ matrix.python-version != '2.7' }}
-      name: ${{ matrix.python-version }} - ${{ matrix.os }}
+    - name: ${{ matrix.python-version }} - ${{ matrix.os }}
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
[This isn't supported anymore](https://github.com/actions/runner-images/issues/7401), and that's why it's in a "Pending" state on all commits/prs.