### PR TITLE
Have dependabot update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: monthly
     assignees:
-      - "StanFromIreland"
+      - "@python/tzdata-maintainers"
     groups:
       actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    assignees:
+      - "StanFromIreland"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
As suggested by @pganssle in the previous update PR. File based on [python-docs-theme's](https://github.com/python/python-docs-theme/blob/main/.github/dependabot.yml) and [documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference).