### PR TITLE
Verify signatures of tarballs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps =
     requests
     click
     parver
+    python-gnupg
 commands =
     python update.py {posargs}
 


### PR DESCRIPTION
It wasn't quite clear which of the [three keys are used](https://pgp.mit.edu/pks/lookup?search=eggert%40cs.ucla.edu+&op=index), so I tested all three and found [the one](https://keyserver.ubuntu.com/pks/lookup?search=ed97e90e62aa7e34&fingerprint=on&op=index) that was used for the last release. Furthermore, reading [this discussion](https://lists.iana.org/hyperkitty/list/tz@iana.org/thread/BOENNLXPCUSUVLKAVUBFIVBZDBU5D5Q3/), it seems the future of the signing is not certain.

@eggert can you please confirm that `ed97e90e62aa7e34` is used?