### PR TITLE
Isolate package build and publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 # This workflow is triggered two ways:
 #
-# 1. When a commit is made, the workflow will upload the package to
+# 1. When a tag is created, the workflow will upload the package to
 #    test.pypi.org.
 # 2. When a release is made, the workflow will upload the package to pypi.org.
 #
@@ -34,13 +34,13 @@ jobs:
 
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
 
-  # Publish to Test PyPI on every commit on main.
+  # Publish to Test PyPI for every tag.
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     if: |
       github.repository_owner == 'python'
       && github.event_name == 'push'
-      && github.ref == 'refs/heads/main'
+      && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: build-package
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,12 @@ jobs:
 
   test-package:
     name: Test package
+    if: |
+      github.repository_owner == 'python'
+      && (
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+        || github.event.action == 'published'
+      )
     needs: build-package
     uses: ./.github/workflows/tests.yml
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,11 @@ jobs:
 
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
 
+  test-package:
+    name: Test package
+    needs: build-package
+    uses: ./.github/workflows/tests.yml
+
   # Publish to Test PyPI for every tag.
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
@@ -42,7 +47,7 @@ jobs:
       && github.event_name == 'push'
       && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    needs: build-package
+    needs: test-package
 
     permissions:
       id-token: write
@@ -66,7 +71,7 @@ jobs:
       github.repository_owner == 'python'
       && github.event.action == 'published'
     runs-on: ubuntu-latest
-    needs: build-package
+    needs: test-package
 
     environment:
       name: release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,6 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  # Always build & lint package.
   build-package:
     name: Build & verify package
     runs-on: ubuntu-latest
@@ -31,7 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
@@ -61,7 +59,6 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
 
-  # Publish to PyPI on GitHub Releases.
   release-pypi:
     name: Publish to PyPI
     # Only run for published releases.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 # This workflow is triggered two ways:
 #
-# 1. When a tag is created, the workflow will upload the package to
+# 1. When a commit is made, the workflow will upload the package to
 #    test.pypi.org.
 # 2. When a release is made, the workflow will upload the package to pypi.org.
 #
@@ -9,49 +9,84 @@
 name: Upload package
 
 on:
-  release:
-    types: [created]
   push:
-    tags:
-      - '*'
+  pull_request:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 1
 
 jobs:
-  deploy:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
     runs-on: ubuntu-latest
-    environment:
-      name: release
-      url: https://pypi.org/p/tzdata
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
+
+  # Publish to Test PyPI on every commit on main.
+  release-test-pypi:
+    name: Publish in-dev package to test.pypi.org
+    if: |
+      github.repository_owner == 'python'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-package
+
     permissions:
       id-token: write
+
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U tox
-    - name: Create tox environments
-      run: |
-        tox -p -e py,build --notest
-    - name: Run tests
-      run: |
-        tox -e py
-    - name: Build package
-      run: |
-        tox -e build
-    - name: Publish package (TestPyPI)
-      if: github.event_name == 'push'
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        verbose: true
-    - name: Publish package
-      if: github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-      with:
-        verbose: true
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Packages
+          path: dist
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  # Publish to PyPI on GitHub Releases.
+  release-pypi:
+    name: Publish to PyPI
+    # Only run for published releases.
+    if: |
+      github.repository_owner == 'python'
+      && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    environment:
+      name: release
+      url: >-
+        https://pypi.org/project/tzdata/${{
+          github.event.release.tag_name
+        }}
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Packages
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
   test-package:
     name: Test package
     if: |
-      github.repository_owner == 'python'
+      github.event.repository.fork == false
       && (
         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
         || github.event.action == 'published'
@@ -49,7 +49,7 @@ jobs:
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     if: |
-      github.repository_owner == 'python'
+      github.event.repository.fork == false
       && github.event_name == 'push'
       && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -74,7 +74,7 @@ jobs:
     name: Publish to PyPI
     # Only run for published releases.
     if: |
-      github.repository_owner == 'python'
+      github.event.repository.fork == false
       && github.event.action == 'published'
     runs-on: ubuntu-latest
     needs: test-package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,9 +45,9 @@ jobs:
     needs: build-package
     uses: ./.github/workflows/tests.yml
 
-  # Publish to Test PyPI for every tag.
+  # Publish to TestPyPI for every tag.
   release-test-pypi:
-    name: Publish in-dev package to test.pypi.org
+    name: Publish to TestPyPI
     if: |
       github.event.repository.fork == false
       && github.event_name == 'push'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        toxenv: ["build", "precommit", "typing", "docs"]
+        toxenv: ["precommit", "typing", "docs"]
     env:
       TOXENV: ${{ matrix.toxenv }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_call:
   workflow_dispatch:
 
 permissions: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.check-wheel-contents]
+ignore = ["W002"]
+
 [tool.isort]
 atomic=true
 force_grid_wrap=0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ requires = ["setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.check-wheel-contents]
+# The wheel contains duplicate files.
+# This is by design, see https://github.com/eggert/tz/blob/main/backward
+# Let's ignore the warning:
 ignore = ["W002"]
 
 [tool.isort]

--- a/tox.ini
+++ b/tox.ini
@@ -70,15 +70,3 @@ deps =
 commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" "{toxinidir}/docs" \
                     "{toxinidir}/docs/_output" {posargs: -j auto --color -bhtml}
-
-[testenv:build]
-description = Build a wheel and source distribution
-skip_install = True
-deps =
-    build
-    twine
-commands =
-    python -c "from pathlib import Path; \
-               [x.unlink(missing_ok=True) for x in Path('{toxinidir}/dist').glob('*')]"
-    python -m build -o {toxinidir}/dist {toxinidir}
-    twine check {toxinidir}/dist/*


### PR DESCRIPTION
This follows the https://github.com/python/blurb/blob/main/.github/workflows/release.yml pattern as much as possible, which is very similar to the other PyPI Trusted Publishing workflows we have under https://github.com/python/, which will help ease maintenance burden.

As before, it publishes to Test PyPI for commits to main, and to prod PyPI when releases are created.

The main difference is we build the artifacts (sdist and wheel) in an isolated job then upload as GH artifacts. Then another isolated job will download and publish to the relevant index.

This isolates the installation of build deps from the job that uploads, and helps prevent supply chain attacks.

It will also run when we're not in "publish mode", and verify the artifacts can be built. We also get a nice summary of the packages and their contents. For example:

* https://github.com/hugovk/tzdata/actions/runs/24910411359

This also includes extra linting of artifacts. There was a bunch of "W002: Wheel contains duplicate files" warnings:

* https://github.com/hugovk/tzdata/actions/runs/24910168446/job/72949537402

I've ignored these, as I think these are inherent to how tzdata is built? Anyway, this is pre-existing in the last published wheel: `check-wheel-contents --no-config tzdata-2026.2-py2.py3-none-any.whl`