### PR TITLE
Make open PR check stricter

### DIFF
--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -21,7 +21,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_EXISTS=$(gh pr --repo "$GITHUB_REPOSITORY" \
-                      list --search "Update tzdata to version" \
+                      list --state open \
+                      --search 'in:title "Update tzdata to version"' \
                       --json number --jq '.[] | .number')
           if [ -n "$PR_EXISTS" ]; then
             echo "A PR updating the tzdata version already exists: https://github.com/python/tzdata/pulls/${PR_EXISTS}"

--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -25,7 +25,7 @@ jobs:
                       --search 'in:title "Update tzdata to version"' \
                       --json number --jq '.[] | .number')
           if [ -n "$PR_EXISTS" ]; then
-            echo "A PR updating the tzdata version already exists: https://github.com/python/tzdata/pulls/${PR_EXISTS}"
+            echo "A PR updating the tzdata version already exists: https://github.com/python/tzdata/pull/${PR_EXISTS}"
             echo "pr_exists=true" >> "$GITHUB_OUTPUT"
             exit 0
           else


### PR DESCRIPTION
It has been triggering on unrelated PRs, like #130. For example, yesterday's run: https://github.com/python/tzdata/actions/runs/25428071486/job/74586738062