### PR TITLE
Use the "release" environment on TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-package
 
+    environment:
+      name: release
+      url: >-
+        https://pypi.org/project/tzdata/${{
+          github.event.release.tag_name
+        }}
+
     permissions:
       id-token: write
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
     environment:
       name: release
       url: >-
-        https://pypi.org/project/tzdata/${{
+        https://test.pypi.org/project/tzdata/${{
           github.event.release.tag_name
         }}
 


### PR DESCRIPTION
Trusted publishing is set up to require that the release be done by publish.yml in the "release" environment, which is only set up for the PyPI environment.