### PR TITLE
Fixes to maintaining doc, add Stan to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 Apache Software License 2.0
 
 Copyright (c) 2020, Paul Ganssle (Google)
+Copyright (c) 2026, Stan Ulbrych
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/maintaining.rst
+++ b/docs/maintaining.rst
@@ -50,14 +50,14 @@ repository root, and it is updated in two ways:
 
 1. The "base version" (e.g. 2020.1) is set by ``tox -e update``.
 2. The additional markers such as pre (release candidate), post and dev are
-   managed by ``tox -e bump_version``.
+   managed by ``tox -e bump``.
 
 The version follows the scheme::
 
     YYYY.minor[rcX][.postY][.devZ]
 
 Bumping any component removes all values to its right as well, so for example,
-if the base version were ``20201rc1.post2.dev0``::
+if the base version were ``2020.1rc1.post2.dev0``::
 
     $ tox -e bump -- --dev --dry-run
     ...
@@ -78,8 +78,8 @@ To remove all additional markers and get a simple "release" version, use
     ...
     2020.1rc1.post2.dev0 → 2020.1
 
-For more information on how to use ``bump_version``, run ``tox -e bump_version
--- -help``.
+For more information on how to use ``bump_version``, run ``tox -e bump
+-- --help``.
 
 Making a release
 ----------------
@@ -112,4 +112,4 @@ is immutable and each release burns a version number.
 
 .. Links
 .. |tox| replace:: ``tox``
-.. _tox: https://tox.readthedocs.io/en/latest/
+.. _tox: https://tox.wiki/en/latest/


### PR DESCRIPTION
I couldn't push new commits to #142 but I wanted to refactor this into two commits and explicitly co-author the "Add Stan to license" commit myself as a minor but clear endorsement there, so I've made a new PR.